### PR TITLE
fix(crypto): correct export paths

### DIFF
--- a/packages/crypto/package.json
+++ b/packages/crypto/package.json
@@ -12,18 +12,18 @@
   "license": "MIT",
   "type": "module",
   "main": "./index.cjs",
-  "module": "./dist/rx-nostr-crypto.js",
+  "module": "./dist/crypto.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "import": {
         "types": "./dist/index.d.ts",
-        "default": "./dist/rx-nostr-crypto.js"
+        "default": "./dist/crypto.js"
       },
       "require": {
         "types": "./dist/index.d.ts",
-        "node": "./dist/rx-nostr-crypto.cjs",
-        "default": "./dist/rx-nostr-crypto.umd.cjs"
+        "node": "./dist/crypto.cjs",
+        "default": "./dist/crypto.umd.cjs"
       }
     },
     "./src": "./src/index.ts",


### PR DESCRIPTION
Vite 5 derives the output filename from the package.json name field,
producing crypto.js/cjs/umd.cjs instead of rx-nostr-crypto.* which
was the Vite 4 behavior based on the lib name option.

https://github.com/penpenpng/rx-nostr/issues/185